### PR TITLE
Update the name of the buildpack

### DIFF
--- a/bin/detect
+++ b/bin/detect
@@ -19,4 +19,4 @@ if [ ! -f "$BUILD_DIR/requirements.txt" ] && [ ! -f "$BUILD_DIR/setup.py" ] && [
   exit 1
 fi
 
-echo Python
+echo "Python (AltSchool Buildpack)"

--- a/buildpack.toml
+++ b/buildpack.toml
@@ -1,5 +1,5 @@
 [buildpack]
-name = "Python"
+name = "Python (AltSchool Builpack)"
 
   [publish.Ignore]
   files = [


### PR DESCRIPTION
# Purpose
The goal is to recognize which apps use this buildpack vs the generic Python buildpack when we do: `heroku apps --json`

# Testing
Before:
```
"buildpack_provided_description": "Python",
```

After:
```
"buildpack_provided_description": "Python (AltSchool Buildpack)",
```
Unfortunately, the app needs to be re-deployed for the change to occur (also tested that the app deploys successfully)